### PR TITLE
Fix wrong parameter for safe

### DIFF
--- a/utils/ffmpeg.go
+++ b/utils/ffmpeg.go
@@ -50,7 +50,7 @@ func MergeToMP4(paths []string, mergedFilePath string, filename string) error {
 	mergeFile.Close() // nolint
 
 	cmd := exec.Command(
-		"ffmpeg", "-y", "-f", "concat", "-safe", "-1",
+		"ffmpeg", "-y", "-f", "concat", "-safe", "0",
 		"-i", mergeFilePath, "-c", "copy", "-bsf:a", "aac_adtstoasc", mergedFilePath,
 	)
 	return runMergeCmd(cmd, paths, mergeFilePath)


### PR DESCRIPTION
`-safe` option should be 1 or 0. 

From `ffmpeg -h long`:

```
concat demuxer AVOptions:
  -safe              <boolean>    .D......... enable safe mode (default true)
```

The `-safe -1` used to be tolerated in old(er) version of ffmpeg, but such historical behavior is totally removed in https://github.com/FFmpeg/FFmpeg/commit/46fb395952be32692385449ee214461603480b4b, it's invalid and will throw error:
```
[concat demuxer @ 0000000000566e80] Unable to parse option value "-1" as boolean
[concat demuxer @ 0000000000566e80] Error setting option safe to value -1.
```

This PR fixes it. 

