### PR TITLE
bilibili去掉活动作品

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -40,9 +40,12 @@ func GetImages(html, imgClass string, urlHandler func(string) string) (string, [
 // Title get title
 func Title(doc *goquery.Document) string {
 	var title string
-	title = strings.Replace(
-		strings.TrimSpace(doc.Find("h1").First().Text()), "\n", "", -1,
-	)
+	h1Elem := doc.Find("h1").First()
+	h1Title, found := h1Elem.Attr("title")
+	if !found {
+		h1Title = h1Elem.Text()
+	}
+	title = strings.Replace(strings.TrimSpace(h1Title), "\n", "", -1)
 	if title == "" {
 		// Bilibili: Some movie page got no h1 tag
 		title, _ = doc.Find("meta[property=\"og:title\"]").Attr("content")


### PR DESCRIPTION
现状：B站的下载文件总是带有“活动作品”4个字
想要达到的效果：不带有“活动作品”
分析： B站的up主因收益，经常选择做活动作品，而活动作品在页面h1里面带有“活动作品”的标签
解决方案：在可能的情况下，取h1的title属性