### PR TITLE
no streams panic

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -537,6 +537,10 @@ func (downloader *Downloader) aria2(title string, stream *types.Stream) error {
 
 // Download download urls
 func (downloader *Downloader) Download(data *types.Data) error {
+	if len(data.Streams) == 0 {
+		return fmt.Errorf("no streams in title %s", data.Title)
+	}
+
 	sortedStreams := genSortedStreams(data.Streams)
 	if downloader.option.InfoOnly {
 		printInfo(data, sortedStreams)


### PR DESCRIPTION
when there have no streams the progress will panic
```go
lux  "https://www.bilibili.com/bangumi/play/ep257474" 
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/iawia002/lux/downloader.(*Downloader).Download(0xc000334370, 0xc0003030e0)
        /Users/bojue/go/pkg/mod/github.com/iawia002/lux@v0.12.0/downloader/downloader.go:554 +0xbcc
main.download(0xc00019fbf8, {0x7ffeefbffa8c, 0x2e})
        /Users/bojue/go/pkg/mod/github.com/iawia002/lux@v0.12.0/main.go:331 +0x95d
main.main.func2(0xc000262e00)
        /Users/bojue/go/pkg/mod/github.com/iawia002/lux@v0.12.0/main.go:247 +0x73b
github.com/urfave/cli/v2.(*App).RunContext(0xc0000a7520, {0x1b0a590, 0xc0000280a8}, {0xc000020040, 0x2, 0x2})
        /Users/bojue/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:322 +0x7a8
github.com/urfave/cli/v2.(*App).Run(...)
        /Users/bojue/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
        /Users/bojue/go/pkg/mod/github.com/iawia002/lux@v0.12.0/main.go:266 +0x16c6

```
just fix it to insure the progress will not panic