### PR TITLE
Link to the correct AUR page

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ brew install lux
 
 ### Arch Linux
 
-For Arch Users [AUR](https://aur.archlinux.org/packages/lux) package is available.
+For Arch Users [AUR](https://aur.archlinux.org/packages/lux-dl/) package is available.
 
 ### Void Linux
 


### PR DESCRIPTION
Fix the link to [lux-dl](https://aur.archlinux.org/packages/lux-dl/)
instead of [lux](https://aur.archlinux.org/packages/lux), which is
described as "POSIX Shell script to easily control brightness on
backlight controllers."