### PR TITLE
feat: print better error message when error

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -255,9 +255,10 @@ func New() *cli.App {
 				if err := download(c, videoURL); err != nil {
 					fmt.Fprintf(
 						color.Output,
-						"Downloading %s error:\n%s\n",
-						color.CyanString("%s", videoURL), color.RedString("%v", err),
+						"Downloading %s error:\n",
+						color.CyanString("%s", videoURL),
 					)
+					fmt.Printf("%+v\n", err)
 					isErr = true
 				}
 			}

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
+
 	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
-
 	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/acfun/acfun.go
+++ b/extractors/acfun/acfun.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 
 	jsoniter "github.com/json-iterator/go"
-
 	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/acfun/acfun.go
+++ b/extractors/acfun/acfun.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
@@ -37,7 +38,7 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(URL string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.GetByte(URL, referer, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	epDatas := make([]*episodeData, 0)
@@ -45,7 +46,7 @@ func (e *extractor) Extract(URL string, option extractors.Options) ([]*extractor
 	if option.Playlist {
 		list, err := resolvingEpisodes(html)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		items := utils.NeedDownloadList(option.Items, option.ItemStart, option.ItemEnd, len(list.Episodes))
 
@@ -55,7 +56,7 @@ func (e *extractor) Extract(URL string, option extractors.Options) ([]*extractor
 	} else {
 		bgData, _, err := resolvingData(html)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		epDatas = append(epDatas, &bgData.episodeData)
 	}
@@ -151,12 +152,12 @@ func resolvingData(html []byte) (*bangumiData, *videoInfo, error) {
 	groups := pattern.FindSubmatch(html)
 	err := jsoniter.Unmarshal(groups[1], bgData)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.WithStack(err)
 	}
 
 	err = jsoniter.UnmarshalFromString(bgData.CurrentVideoInfo.KsPlayJSON, vInfo)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.WithStack(err)
 	}
 	return bgData, vInfo, nil
 }
@@ -168,7 +169,7 @@ func resolvingEpisodes(html []byte) (*episodeList, error) {
 	groups := pattern.FindSubmatch(html)
 	err := jsoniter.Unmarshal(groups[1], list)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return list, nil
 }

--- a/extractors/acfun/acfun.go
+++ b/extractors/acfun/acfun.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	jsoniter "github.com/json-iterator/go"
+
 	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/bcy/bcy.go
+++ b/extractors/bcy/bcy.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/bcy/bcy.go
+++ b/extractors/bcy/bcy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -2,7 +2,6 @@ package bilibili
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -49,7 +49,7 @@ func genAPI(aid, cid, quality int, bvid string, bangumi bool, cookie string) (st
 			return "", err
 		}
 		if t.Code != 0 {
-			return "", fmt.Errorf("cookie error: %s", t.Message)
+			return "", errors.Errorf("cookie error: %s", t.Message)
 		}
 		utoken = t.Data.Token
 	}
@@ -94,7 +94,7 @@ func extractBangumi(url, html string, extractOption extractors.Options) ([]*extr
 	var data bangumiData
 	err := json.Unmarshal([]byte(dataString), &data)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if !extractOption.Playlist {
 		aid := data.EpInfo.Aid
@@ -158,7 +158,7 @@ func getMultiPageData(html string) (*multiPage, error) {
 	}
 	err := json.Unmarshal([]byte(multiPageDataString[1]), &data)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return &data, nil
 }
@@ -166,7 +166,7 @@ func getMultiPageData(html string) (*multiPage, error) {
 func extractNormalVideo(url, html string, extractOption extractors.Options) ([]*extractors.Data, error) {
 	pageData, err := getMultiPageData(html)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if !extractOption.Playlist {
 		// handle URL that has a playlist, mainly for unified titles
@@ -183,7 +183,7 @@ func extractNormalVideo(url, html string, extractOption extractors.Options) ([]*
 		}
 
 		if len(pageData.VideoData.Pages) < p || p < 1 {
-			return nil, extractors.ErrURLParseFailed
+			return nil, errors.WithStack(extractors.ErrURLParseFailed)
 		}
 
 		page := pageData.VideoData.Pages[p-1]
@@ -246,7 +246,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	var err error
 	html, err := request.Get(url, referer, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// set thread number to 1 manually to avoid http 412 error
@@ -421,7 +421,7 @@ func subtitleTransform(body []byte) ([]byte, error) {
 	captionData := bilibiliSubtitleFormat{}
 	err := json.Unmarshal(body, &captionData)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	for i := 0; i < len(captionData.Body); i++ {

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/douyin/douyin.go
+++ b/extractors/douyin/douyin.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/douyin/douyin.go
+++ b/extractors/douyin/douyin.go
@@ -2,13 +2,13 @@ package douyin
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -29,7 +29,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	if strings.Contains(url, "v.douyin.com") {
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		c := http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -38,7 +38,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		}
 		resp, err := c.Do(req)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		url = resp.Header.Get("location")
 	}
@@ -48,16 +48,16 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		return nil, errors.New("unable to get video ID")
 	}
 	if itemIds == nil || len(itemIds) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	itemId := itemIds[len(itemIds)-1]
 	jsonData, err := request.Get("https://www.iesdouyin.com/web/api/v2/aweme/iteminfo/?item_ids="+itemId, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var douyin douyinData
 	if err = json.Unmarshal([]byte(jsonData), &douyin); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	urlData := make([]*extractors.Part, 0)
@@ -70,12 +70,12 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 			realURL := img.URLList[len(img.URLList)-1]
 			size, err := request.Size(realURL, url)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithStack(err)
 			}
 			totalSize += size
 			_, ext, err := utils.GetNameAndExt(realURL)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithStack(err)
 			}
 			urlData = append(urlData, &extractors.Part{
 				URL:  realURL,
@@ -88,7 +88,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		realURL := "https://aweme.snssdk.com/aweme/v1/play/?video_id=" + douyin.ItemList[0].Video.PlayAddr.URI + "&ratio=720p&line=0"
 		totalSize, err = request.Size(realURL, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		urlData = append(urlData, &extractors.Part{
 			URL:  realURL,

--- a/extractors/douyin/douyin.go
+++ b/extractors/douyin/douyin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/douyu/douyu.go
+++ b/extractors/douyu/douyu.go
@@ -2,11 +2,11 @@ package douyu
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -68,32 +68,32 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	titles := utils.MatchOneOf(html, `<title>(.*?)</title>`)
 	if titles == nil || len(titles) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	title := titles[1]
 
 	vids := utils.MatchOneOf(url, `https?://v.douyu.com/show/(\S+)`)
 	if vids == nil || len(vids) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	vid := vids[1]
 
 	dataString, err := request.Get("http://vmobile.douyu.com/video/getInfo?vid="+vid, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	dataDict := new(douyuData)
 	if err := json.Unmarshal([]byte(dataString), dataDict); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	m3u8URLs, totalSize, err := douyuM3u8(dataDict.Data.VideoURL)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urls := make([]*extractors.Part, len(m3u8URLs))
 	for index, u := range m3u8URLs {

--- a/extractors/douyu/douyu.go
+++ b/extractors/douyu/douyu.go
@@ -3,11 +3,11 @@ package douyu
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/douyu/douyu.go
+++ b/extractors/douyu/douyu.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/eporner/eporner.go
+++ b/extractors/eporner/eporner.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-
 	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/eporner/eporner.go
+++ b/extractors/eporner/eporner.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
@@ -106,7 +107,7 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(u string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(u, u, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var title string
 	desc := utils.MatchOneOf(html, `<title>(.+?)</title>`)
@@ -117,7 +118,7 @@ func (e *extractor) Extract(u string, option extractors.Options) ([]*extractors.
 	}
 	uu, err := url.Parse(u)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	srcs := getSrc(html)
 	streams := make(map[string]*extractors.Stream, len(srcs))
@@ -126,7 +127,7 @@ func (e *extractor) Extract(u string, option extractors.Options) ([]*extractors.
 		// skipping an extra HEAD request to the URL.
 		// size, err := request.Size(srcurl, u)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		urlData := &extractors.Part{
 			URL:  srcurl,

--- a/extractors/eporner/eporner.go
+++ b/extractors/eporner/eporner.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+
 	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/errors.go
+++ b/extractors/errors.go
@@ -1,7 +1,7 @@
 package extractors
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 var (

--- a/extractors/errors.go
+++ b/extractors/errors.go
@@ -1,7 +1,7 @@
 package extractors
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/iawia002/lux/utils"
-
 	"github.com/pkg/errors"
+
+	"github.com/iawia002/lux/utils"
 )
 
 var lock sync.RWMutex

--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 var lock sync.RWMutex
@@ -35,7 +36,7 @@ func Extract(u string, option Options) ([]*Data, error) {
 	} else {
 		u, err := url.ParseRequestURI(u)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		if u.Host == "haokan.baidu.com" {
 			domain = "haokan"
@@ -49,7 +50,7 @@ func Extract(u string, option Options) ([]*Data, error) {
 	}
 	videos, err := extractor.Extract(u, option)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	for _, v := range videos {
 		v.FillUpStreamsData()

--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/facebook/facebook.go
+++ b/extractors/facebook/facebook.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/facebook/facebook.go
+++ b/extractors/facebook/facebook.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -25,11 +26,11 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	var err error
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	titles := utils.MatchOneOf(html, `<title>([^<]+)</title>`)
 	if titles == nil || len(titles) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	title := strings.TrimSpace(titles[1])
@@ -53,7 +54,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 
 		size, err := request.Size(u, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 
 		urlData := &extractors.Part{

--- a/extractors/facebook/facebook.go
+++ b/extractors/facebook/facebook.go
@@ -4,11 +4,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/geekbang/geekbang.go
+++ b/extractors/geekbang/geekbang.go
@@ -2,7 +2,6 @@ package geekbang
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -63,7 +63,7 @@ func geekM3u8(url string) ([]geekURLInfo, error) {
 	)
 	urls, err := utils.M3u8URLs(url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	for _, u := range urls {
 		temp = geekURLInfo{
@@ -87,7 +87,7 @@ func (e *extractor) Extract(url string, _ extractors.Options) ([]*extractors.Dat
 	var err error
 	matches := utils.MatchOneOf(url, `https?://time.geekbang.org/course/detail/(\d+)-(\d+)`)
 	if matches == nil || len(matches) < 3 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	// Get video information
@@ -95,13 +95,13 @@ func (e *extractor) Extract(url string, _ extractors.Options) ([]*extractors.Dat
 	params := strings.NewReader(fmt.Sprintf(`{"id": %q}`, matches[2]))
 	res, err := request.Request(http.MethodPost, "https://time.geekbang.org/serv/v1/article", params, heanders)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	defer res.Body.Close() // nolint
 
 	var data geekData
 	if err = json.NewDecoder(res.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	if data.Code < 0 {
@@ -116,13 +116,13 @@ func (e *extractor) Extract(url string, _ extractors.Options) ([]*extractors.Dat
 	params = strings.NewReader("{\"source_type\":1,\"aid\":" + string(matches[2]) + ",\"video_id\":\"" + string(data.Data.VideoID) + "\"}")
 	res, err = request.Request(http.MethodPost, "https://time.geekbang.org/serv/v3/source_auth/video_play_auth", params, heanders)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	defer res.Body.Close() // nolint
 
 	var playAuth videoPlayAuth
 	if err = json.NewDecoder(res.Body).Decode(&playAuth); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	if playAuth.Code < 0 {
@@ -133,13 +133,13 @@ func (e *extractor) Extract(url string, _ extractors.Options) ([]*extractors.Dat
 	heanders = map[string]string{"Accept-Encoding": ""}
 	res, err = request.Request(http.MethodGet, "http://ali.mantv.top/play/info?playAuth="+playAuth.Data.PlayAuth, nil, heanders)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	defer res.Body.Close() // nolint
 
 	var playInfo playInfo
 	if err = json.NewDecoder(res.Body).Decode(&playInfo); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	title := data.Data.Title
@@ -150,7 +150,7 @@ func (e *extractor) Extract(url string, _ extractors.Options) ([]*extractors.Dat
 		m3u8URLs, err := geekM3u8(media.URL)
 
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 
 		urls := make([]*extractors.Part, len(m3u8URLs))

--- a/extractors/geekbang/geekbang.go
+++ b/extractors/geekbang/geekbang.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/geekbang/geekbang.go
+++ b/extractors/geekbang/geekbang.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/haokan/haokan.go
+++ b/extractors/haokan/haokan.go
@@ -3,11 +3,11 @@ package haokan
 import (
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/haokan/haokan.go
+++ b/extractors/haokan/haokan.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/haokan/haokan.go
+++ b/extractors/haokan/haokan.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -23,12 +24,12 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	titles := utils.MatchOneOf(html, `property="og:title"\s+content="(.+?)"`)
 	if titles == nil || len(titles) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	title := titles[1]
 
@@ -41,19 +42,19 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	}
 
 	if urls == nil || len(urls) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	playurl := strings.Replace(urls[1], `\/`, `/`, -1)
 
 	size, err := request.Size(playurl, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	_, ext, err := utils.GetNameAndExt(playurl)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	streams := map[string]*extractors.Stream{

--- a/extractors/hupu/hupu.go
+++ b/extractors/hupu/hupu.go
@@ -1,11 +1,11 @@
 package hupu
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/hupu/hupu.go
+++ b/extractors/hupu/hupu.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -20,7 +21,7 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	var title string
@@ -36,12 +37,12 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	if len(urlDesc) > 1 {
 		videoUrl = urlDesc[1]
 	} else {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	size, err := request.Size(videoUrl, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urlData := &extractors.Part{
 		URL:  videoUrl,

--- a/extractors/hupu/hupu.go
+++ b/extractors/hupu/hupu.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/huya/huya.go
+++ b/extractors/huya/huya.go
@@ -1,11 +1,11 @@
 package huya
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/huya/huya.go
+++ b/extractors/huya/huya.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -22,7 +23,7 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	var title string
@@ -38,12 +39,12 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	if len(videoDesc) > 1 {
 		videoUrl = huyaVideoHost + videoDesc[1]
 	} else {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	size, err := request.Size(videoUrl, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urlData := &extractors.Part{
 		URL:  videoUrl,

--- a/extractors/huya/huya.go
+++ b/extractors/huya/huya.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/instagram/instagram.go
+++ b/extractors/instagram/instagram.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/instagram/instagram.go
+++ b/extractors/instagram/instagram.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -40,7 +41,7 @@ func New() extractors.Extractor {
 func extractImageFromPage(html, url string) (map[string]*extractors.Stream, error) {
 	_, realURLs, err := parser.GetImages(html, "EmbeddedMediaImage", nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	urls := make([]*extractors.Part, 0, len(realURLs))
@@ -48,7 +49,7 @@ func extractImageFromPage(html, url string) (map[string]*extractors.Stream, erro
 	for _, realURL := range realURLs {
 		size, err := request.Size(realURL, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		urlData := &extractors.Part{
 			URL:  realURL,
@@ -70,7 +71,7 @@ func extractImageFromPage(html, url string) (map[string]*extractors.Stream, erro
 func extractFromData(dataString, url string) (map[string]*extractors.Stream, error) {
 	var data instagram
 	if err := json.Unmarshal([]byte(dataString), &data); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	urls := make([]*extractors.Part, 0, len(data.ShortcodeMedia.EdgeSidecar.Edges))
@@ -87,7 +88,7 @@ func extractFromData(dataString, url string) (map[string]*extractors.Stream, err
 
 		size, err := request.Size(realURL, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		urlData := &extractors.Part{
 			URL:  realURL,
@@ -111,18 +112,18 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	// Instagram is forcing a login to access the page, so we use the embed page to bypass that.
 	u, err := netURL.Parse(url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	id := u.Path[strings.LastIndex(u.Path, "/")+1:]
 	u.Path = path.Join(u.Path, "embed")
 
 	html, err := request.Get(u.String(), url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	dataStrings := utils.MatchOneOf(html, `window\.__additionalDataLoaded\('graphql',(.*)\);`)
 	if dataStrings == nil || len(dataStrings) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	dataString := dataStrings[1]
 
@@ -133,7 +134,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		streams, err = extractFromData(dataString, url)
 	}
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return []*extractors.Data{

--- a/extractors/instagram/instagram.go
+++ b/extractors/instagram/instagram.go
@@ -6,12 +6,12 @@ import (
 	"path"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/iqiyi/iqiyi.go
+++ b/extractors/iqiyi/iqiyi.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/iqiyi/iqiyi.go
+++ b/extractors/iqiyi/iqiyi.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/kuaishou/kuaishou.go
+++ b/extractors/kuaishou/kuaishou.go
@@ -1,7 +1,6 @@
 package kuaishou
 
 import (
-	"errors"
 	"net/http"
 	"regexp"
 	"strings"
@@ -9,6 +8,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -49,14 +49,14 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 
 	cookies, err := fetchCookies(url, headers)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	headers["Cookie"] = cookies
 
 	html, err := request.Get(url, url, headers)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	titles := utils.MatchOneOf(html, `<title>([^<]+)</title>`)
@@ -74,14 +74,14 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	for quality, qualityReg := range qualityRegMap {
 		matcher := qualityReg.FindStringSubmatch(html)
 		if len(matcher) != 2 {
-			return nil, extractors.ErrURLParseFailed
+			return nil, errors.WithStack(extractors.ErrURLParseFailed)
 		}
 
 		u := strings.ReplaceAll(matcher[1], `\u002F`, "/")
 
 		size, err := request.Size(u, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 
 		urlData := &extractors.Part{

--- a/extractors/kuaishou/kuaishou.go
+++ b/extractors/kuaishou/kuaishou.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/kuaishou/kuaishou.go
+++ b/extractors/kuaishou/kuaishou.go
@@ -5,11 +5,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/mgtv/mgtv.go
+++ b/extractors/mgtv/mgtv.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -109,7 +110,7 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	vid := utils.MatchOneOf(
 		url,
@@ -120,7 +121,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		vid = utils.MatchOneOf(html, `vid: (\d+),`)
 	}
 	if vid == nil || len(vid) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	// API extract from https://js.mgtv.com/imgotv-miniv6/global/page/play-tv.js
@@ -142,11 +143,11 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		headers,
 	)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var pm2 mgtvPm2Data
 	if err = json.Unmarshal([]byte(pm2DataString), &pm2); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	dataString, err := request.Get(
@@ -158,11 +159,11 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		headers,
 	)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var mgtvData mgtv
 	if err = json.Unmarshal([]byte(dataString), &mgtvData); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	title := strings.TrimSpace(
@@ -179,15 +180,15 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		addr = mgtvVideoAddr{}
 		addrInfo, err := request.GetByte(mgtvData.Data.StreamDomain[0]+stream.URL, url, headers)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		if err = json.Unmarshal(addrInfo, &addr); err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 
 		m3u8URLs, totalSize, err := mgtvM3u8(addr.Info)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		urls := make([]*extractors.Part, len(m3u8URLs))
 		for index, u := range m3u8URLs {

--- a/extractors/mgtv/mgtv.go
+++ b/extractors/mgtv/mgtv.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/mgtv/mgtv.go
+++ b/extractors/mgtv/mgtv.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/miaopai/miaopai.go
+++ b/extractors/miaopai/miaopai.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/miaopai/miaopai.go
+++ b/extractors/miaopai/miaopai.go
@@ -2,7 +2,6 @@ package miaopai
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -53,7 +53,7 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	ids := utils.MatchOneOf(url, `/media/([^\./]+)`, `/show(?:/channel)?/([^\./]+)`)
 	if ids == nil || len(ids) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	id := ids[1]
 
@@ -65,7 +65,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		url, nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	match := utils.MatchOneOf(jsonString, randomString+`\((.*)\);$`)
@@ -75,13 +75,13 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 
 	err = json.Unmarshal([]byte(match[1]), &data)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	realURL := data.Data.MetaData[0].URLs.M
 	size, err := request.Size(realURL, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urlData := &extractors.Part{
 		URL:  realURL,

--- a/extractors/miaopai/miaopai.go
+++ b/extractors/miaopai/miaopai.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/netease/netease.go
+++ b/extractors/netease/netease.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/netease/netease.go
+++ b/extractors/netease/netease.go
@@ -1,13 +1,13 @@
 package netease
 
 import (
-	"errors"
 	netURL "net/url"
 	"strings"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -31,7 +31,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	if strings.Contains(html, "u-errlg-404") {
 		return nil, errors.New("404 music not found")
@@ -39,19 +39,19 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 
 	titles := utils.MatchOneOf(html, `<meta property="og:title" content="(.+?)" />`)
 	if titles == nil || len(titles) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	title := titles[1]
 
 	realURLs := utils.MatchOneOf(html, `<meta property="og:video" content="(.+?)" />`)
 	if realURLs == nil || len(realURLs) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	realURL, _ := netURL.QueryUnescape(realURLs[1])
 
 	size, err := request.Size(realURL, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urlData := &extractors.Part{
 		URL:  realURL,

--- a/extractors/netease/netease.go
+++ b/extractors/netease/netease.go
@@ -4,11 +4,11 @@ import (
 	netURL "net/url"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/pixivision/pixivision.go
+++ b/extractors/pixivision/pixivision.go
@@ -5,6 +5,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/pixivision/pixivision.go
+++ b/extractors/pixivision/pixivision.go
@@ -1,12 +1,12 @@
 package pixivision
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/pixivision/pixivision.go
+++ b/extractors/pixivision/pixivision.go
@@ -5,6 +5,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -22,22 +23,22 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	title, urls, err := parser.GetImages(html, "am__work__illust  ", nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	parts := make([]*extractors.Part, 0, len(urls))
 	for _, u := range urls {
 		_, ext, err := utils.GetNameAndExt(u)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		size, err := request.Size(u, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		parts = append(parts, &extractors.Part{
 			URL:  u,

--- a/extractors/pornhub/pornhub.go
+++ b/extractors/pornhub/pornhub.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/robertkrimen/otto"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/pornhub/pornhub.go
+++ b/extractors/pornhub/pornhub.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"github.com/robertkrimen/otto"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/qq/qq.go
+++ b/extractors/qq/qq.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/qq/qq.go
+++ b/extractors/qq/qq.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/streamtape/streamtape.go
+++ b/extractors/streamtape/streamtape.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/robertkrimen/otto"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/streamtape/streamtape.go
+++ b/extractors/streamtape/streamtape.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-
 	"github.com/robertkrimen/otto"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/tangdou/tangdou.go
+++ b/extractors/tangdou/tangdou.go
@@ -1,11 +1,11 @@
 package tangdou
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/tangdou/tangdou.go
+++ b/extractors/tangdou/tangdou.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -27,7 +28,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 
 	html, err := request.Get(url, referer, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	videoIDs := utils.MatchAll(html, `<a target="tdplayer" href="(.+?)" class="title">`)
@@ -61,7 +62,7 @@ func tangdouDownload(uri string) *extractors.Data {
 		html, `<div class="title">(.+?)</div>`, `<meta name="description" content="(.+?)"`, `<title>(.+?)</title>`,
 	)
 	if titles == nil || len(titles) < 2 {
-		return extractors.EmptyData(uri, extractors.ErrURLParseFailed)
+		return extractors.EmptyData(uri, errors.WithStack(extractors.ErrURLParseFailed))
 	}
 	title := titles[1]
 
@@ -74,7 +75,7 @@ func tangdouDownload(uri string) *extractors.Data {
 			html, `<div class="video">\s*<script src="(.+?)"`,
 		)
 		if shareURLs == nil || len(shareURLs) < 2 {
-			return extractors.EmptyData(uri, extractors.ErrURLParseFailed)
+			return extractors.EmptyData(uri, errors.WithStack(extractors.ErrURLParseFailed))
 		}
 		shareURL := shareURLs[1]
 
@@ -87,12 +88,12 @@ func tangdouDownload(uri string) *extractors.Data {
 			signedVideo, `src=\\"(.+?)\\"`,
 		)
 		if realURLs == nil || len(realURLs) < 2 {
-			return extractors.EmptyData(uri, extractors.ErrURLParseFailed)
+			return extractors.EmptyData(uri, errors.WithStack(extractors.ErrURLParseFailed))
 		}
 		realURL = realURLs[1]
 	} else {
 		if len(videoURLs) < 2 {
-			return extractors.EmptyData(uri, extractors.ErrURLParseFailed)
+			return extractors.EmptyData(uri, errors.WithStack(extractors.ErrURLParseFailed))
 		}
 		realURL = videoURLs[1]
 	}

--- a/extractors/tangdou/tangdou.go
+++ b/extractors/tangdou/tangdou.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/tiktok/tiktok.go
+++ b/extractors/tiktok/tiktok.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/tiktok/tiktok.go
+++ b/extractors/tiktok/tiktok.go
@@ -4,10 +4,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/tiktok/tiktok.go
+++ b/extractors/tiktok/tiktok.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -26,7 +27,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:98.0) Gecko/20100101 Firefox/98.0",
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	urlMatcherRegExp := regexp.MustCompile(`"downloadAddr":\s*"([^"]+)"`)
@@ -34,7 +35,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	downloadURLMatcher := urlMatcherRegExp.FindStringSubmatch(html)
 
 	if len(downloadURLMatcher) == 0 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	videoURL := strings.ReplaceAll(downloadURLMatcher[1], `\u002F`, "/")
@@ -44,7 +45,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	titleMatcher := titleMatcherRegExp.FindStringSubmatch(html)
 
 	if len(titleMatcher) == 0 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	title := titleMatcher[1]
@@ -57,7 +58,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 
 	size, err := request.Size(videoURL, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urlData := &extractors.Part{
 		URL:  videoURL,

--- a/extractors/tumblr/tumblr.go
+++ b/extractors/tumblr/tumblr.go
@@ -2,13 +2,13 @@ package tumblr
 
 import (
 	"encoding/json"
-	"errors"
 	"strings"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -48,7 +48,7 @@ func tumblrImageDownload(url, html, title string) ([]*extractors.Data, error) {
 		html, `<script type="application/ld\+json">\s*(.+?)</script>`,
 	)
 	if jsonStrings == nil || len(jsonStrings) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	jsonString := jsonStrings[1]
 
@@ -58,12 +58,12 @@ func tumblrImageDownload(url, html, title string) ([]*extractors.Data, error) {
 		// there are two data structures in the same field(image)
 		var imageList tumblrImageList
 		if err := json.Unmarshal([]byte(jsonString), &imageList); err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		for _, u := range imageList.Image.List {
 			urlData, size, err := genURLData(u, url)
 			if err != nil {
-				return nil, err
+				return nil, errors.WithStack(err)
 			}
 			totalSize += size
 			urls = append(urls, urlData)
@@ -71,12 +71,12 @@ func tumblrImageDownload(url, html, title string) ([]*extractors.Data, error) {
 	} else {
 		var image tumblrImage
 		if err := json.Unmarshal([]byte(jsonString), &image); err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 
 		urlData, size, err := genURLData(image.Image, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		totalSize = size
 		urls = append(urls, urlData)
@@ -102,7 +102,7 @@ func tumblrImageDownload(url, html, title string) ([]*extractors.Data, error) {
 func tumblrVideoDownload(url, html, title string) ([]*extractors.Data, error) {
 	videoURLs := utils.MatchOneOf(html, `<iframe src='(.+?)'`)
 	if videoURLs == nil || len(videoURLs) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	videoURL := videoURLs[1]
 
@@ -111,18 +111,18 @@ func tumblrVideoDownload(url, html, title string) ([]*extractors.Data, error) {
 	}
 	videoHTML, err := request.Get(videoURL, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	realURLs := utils.MatchOneOf(videoHTML, `source src="(.+?)"`)
 	if realURLs == nil || len(realURLs) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	realURL := realURLs[1]
 
 	urlData, size, err := genURLData(realURL, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	streams := map[string]*extractors.Stream{
 		"default": {
@@ -153,12 +153,12 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	// get the title
 	doc, err := parser.GetDoc(html)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	title := parser.Title(doc)
 	if strings.Contains(html, "<iframe src=") {

--- a/extractors/tumblr/tumblr.go
+++ b/extractors/tumblr/tumblr.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/tumblr/tumblr.go
+++ b/extractors/tumblr/tumblr.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/twitter/twitter.go
+++ b/extractors/twitter/twitter.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/twitter/twitter.go
+++ b/extractors/twitter/twitter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/udn/udn.go
+++ b/extractors/udn/udn.go
@@ -3,11 +3,11 @@ package udn
 import (
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/udn/udn.go
+++ b/extractors/udn/udn.go
@@ -1,12 +1,12 @@
 package udn
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -50,12 +50,12 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	url = prepareEmbedURL(url)
 	if len(url) == 0 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var title string
 	desc := utils.MatchOneOf(html, `title: '(.+?)',
@@ -71,11 +71,11 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	}
 	srcURL, err := request.Get("http://"+cdnURL, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	size, err := request.Size(srcURL, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urlData := &extractors.Part{
 		URL:  srcURL,

--- a/extractors/udn/udn.go
+++ b/extractors/udn/udn.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/universal/universal.go
+++ b/extractors/universal/universal.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -21,11 +22,11 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	filename, ext, err := utils.GetNameAndExt(url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	size, err := request.Size(url, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	streams := map[string]*extractors.Stream{
 		"default": {
@@ -41,7 +42,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	}
 	contentType, err := request.ContentType(url, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return []*extractors.Data{

--- a/extractors/universal/universal.go
+++ b/extractors/universal/universal.go
@@ -1,11 +1,11 @@
 package universal
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/universal/universal.go
+++ b/extractors/universal/universal.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/vimeo/vimeo.go
+++ b/extractors/vimeo/vimeo.go
@@ -5,11 +5,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/vimeo/vimeo.go
+++ b/extractors/vimeo/vimeo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -55,24 +56,24 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	if strings.Contains(url, "player.vimeo.com") {
 		html, err = request.Get(url, url, nil)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 	} else {
 		vid = utils.MatchOneOf(url, `vimeo\.com/(\d+)`)[1]
 		html, err = request.Get("https://player.vimeo.com/video/"+vid, url, nil)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 	}
 	jsonStrings := utils.MatchOneOf(html, `var \w+\s?=\s?({.+?});`)
 	if jsonStrings == nil || len(jsonStrings) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	jsonString := jsonStrings[1]
 
 	var vimeoData vimeo
 	if err = json.Unmarshal([]byte(jsonString), &vimeoData); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	streams := make(map[string]*extractors.Stream, len(vimeoData.Request.Files.Progressive))
@@ -80,7 +81,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	for _, video := range vimeoData.Request.Files.Progressive {
 		size, err = request.Size(video.URL, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		urlData := &extractors.Part{
 			URL:  video.URL,

--- a/extractors/vimeo/vimeo.go
+++ b/extractors/vimeo/vimeo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/weibo/weibo.go
+++ b/extractors/weibo/weibo.go
@@ -10,11 +10,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/weibo/weibo.go
+++ b/extractors/weibo/weibo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/weibo/weibo.go
+++ b/extractors/weibo/weibo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -59,7 +60,7 @@ func getXSRFToken() (string, error) {
 func downloadWeiboVideo(url string) ([]*extractors.Data, error) {
 	urldata, err := netURL.Parse(url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	api := fmt.Sprintf(
 		"https://video.h5.weibo.cn/s/video/object?object_id=%s&mid=%s",
@@ -68,22 +69,22 @@ func downloadWeiboVideo(url string) ([]*extractors.Data, error) {
 	jsonString, err := request.Get(api, "", nil)
 
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	rawSummary := utils.MatchOneOf(jsonString, `"summary":"(.+?)",`)[1]
 	summary, err := strconv.Unquote(strings.Replace(strconv.Quote(rawSummary), `\\u`, `\u`, -1))
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	rawhdURL := utils.MatchOneOf(jsonString, `"hd_url":"([^"]+)",`)[1]
 	unescapedhdURL, err := strconv.Unquote(strings.Replace(strconv.Quote(rawhdURL), `\\u`, `\u`, -1))
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	realhdURL := strings.ReplaceAll(unescapedhdURL, `\/`, `/`)
 	hdsize, err := request.Size(realhdURL, "")
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	streams := make(map[string]*extractors.Stream, 2)
 	streams["hd"] = &extractors.Stream{
@@ -100,12 +101,12 @@ func downloadWeiboVideo(url string) ([]*extractors.Data, error) {
 	rawURL := utils.MatchOneOf(jsonString, `"url":"([^"]+)",`)[1]
 	unescapedURL, err := strconv.Unquote(strings.Replace(strconv.Quote(rawURL), `\\u`, `\u`, -1))
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	realURL := strings.ReplaceAll(unescapedURL, `\/`, `/`)
 	size, err := request.Size(realURL, "")
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	streams["sd"] = &extractors.Stream{
 		Parts: []*extractors.Part{
@@ -133,12 +134,12 @@ func downloadWeiboTV(url string) ([]*extractors.Data, error) {
 	APIEndpoint := "https://weibo.com/tv/api/component?page="
 	urldata, err := netURL.Parse(url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	APIURL := APIEndpoint + netURL.QueryEscape(urldata.Path)
 	token, err := getXSRFToken()
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	headers := map[string]string{
 		"Cookie":       "SUB=_2AkMpogLYf8NxqwJRmP0XxG7kbo10ww_EieKf_vMDJRMxHRl-yj_nqm4NtRB6AiIsKFFGRY4-UuGD5B1-Kf9glz3sp7Ii; XSRF-TOKEN=" + token,
@@ -152,25 +153,25 @@ func downloadWeiboTV(url string) ([]*extractors.Data, error) {
 	res, err := request.Request(http.MethodPost, APIURL, payload, headers)
 
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	defer res.Body.Close() // nolint
 	var dataReader io.ReadCloser
 	if res.Header.Get("Content-Encoding") == "gzip" {
 		dataReader, err = gzip.NewReader(res.Body)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 	} else {
 		dataReader = res.Body
 	}
 	var data weiboData
 	if err = json.NewDecoder(dataReader).Decode(&data); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	if data.Data.PlayInfo.URLs == nil {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	realURLs := map[string]string{}
 	for k, v := range data.Data.PlayInfo.URLs {
@@ -184,7 +185,7 @@ func downloadWeiboTV(url string) ([]*extractors.Data, error) {
 	for q, u := range realURLs {
 		size, err := request.Size(u, "")
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		streams[q] = &extractors.Stream{
 			Parts: []*extractors.Part{
@@ -228,13 +229,13 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	}
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	titles := utils.MatchOneOf(
 		html, `"content2": "(.+?)",`, `"status_title": "(.+?)",`,
 	)
 	if titles == nil || len(titles) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	title := titles[1]
 
@@ -242,13 +243,13 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		html, `"stream_url_hd": "(.+?)"`, `"stream_url": "(.+?)"`,
 	)
 	if realURLs == nil || len(realURLs) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	realURL := realURLs[1]
 
 	size, err := request.Size(realURL, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urlData := &extractors.Part{
 		URL:  realURL,

--- a/extractors/ximalaya/ximalaya.go
+++ b/extractors/ximalaya/ximalaya.go
@@ -2,12 +2,12 @@ package ximalaya
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -25,13 +25,13 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// get the title
 	doc, err := parser.GetDoc(html)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	title := parser.Title(doc)
 
@@ -40,28 +40,28 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		return nil, errors.New("unable to get audio ID")
 	}
 	if itemIds == nil || len(itemIds) < 2 {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	itemId := itemIds[len(itemIds)-1]
 
 	jsonData, err := request.Get("https://www.ximalaya.com/revision/play/v1/audio?id="+itemId+"&ptype=1", url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var ximalaya ximalayaData
 	if err = json.Unmarshal([]byte(jsonData), &ximalaya); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	realURL := ximalaya.Data.Src
 	urlData := make([]*extractors.Part, 0)
 	totalSize, err := request.Size(realURL, url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	_, ext, err := utils.GetNameAndExt(realURL)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	urlData = append(urlData, &extractors.Part{
 		URL:  realURL,

--- a/extractors/ximalaya/ximalaya.go
+++ b/extractors/ximalaya/ximalaya.go
@@ -3,12 +3,12 @@ package ximalaya
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/ximalaya/ximalaya.go
+++ b/extractors/ximalaya/ximalaya.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iawia002/lux/parser"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/xvideos/xvideos.go
+++ b/extractors/xvideos/xvideos.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -90,7 +91,7 @@ func New() extractors.Extractor {
 func (e *extractor) Extract(url string, option extractors.Options) ([]*extractors.Data, error) {
 	html, err := request.Get(url, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var title string
 	desc := utils.MatchOneOf(html, `<title>(.+?)</title>`)
@@ -104,7 +105,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	for _, src := range getSrc(html) {
 		size, err := request.Size(src.url, url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		urlData := &extractors.Part{
 			URL:  src.url,

--- a/extractors/xvideos/xvideos.go
+++ b/extractors/xvideos/xvideos.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/xvideos/xvideos.go
+++ b/extractors/xvideos/xvideos.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/yinyuetai/yinyuetai.go
+++ b/extractors/yinyuetai/yinyuetai.go
@@ -2,12 +2,12 @@ package yinyuetai
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -48,12 +48,12 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	var err error
 	html, err := request.Get(apiURL, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	// parse yinyuetai data
 	data := yinyuetaiMvData{}
 	if err = json.Unmarshal([]byte(html), &data); err != nil {
-		return nil, extractors.ErrURLParseFailed
+		return nil, errors.WithStack(extractors.ErrURLParseFailed)
 	}
 	// handle api error
 	if data.Error {

--- a/extractors/yinyuetai/yinyuetai.go
+++ b/extractors/yinyuetai/yinyuetai.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/yinyuetai/yinyuetai.go
+++ b/extractors/yinyuetai/yinyuetai.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/youku/youku.go
+++ b/extractors/youku/youku.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
-
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/extractors/youku/youku.go
+++ b/extractors/youku/youku.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
 	"github.com/iawia002/lux/utils"
+
 	"github.com/pkg/errors"
 )
 

--- a/extractors/youtube/youtube.go
+++ b/extractors/youtube/youtube.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/kkdai/youtube/v2"
+	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
@@ -35,14 +36,14 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 	if !option.Playlist {
 		video, err := e.client.GetVideo(url)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		return []*extractors.Data{e.youtubeDownload(url, video)}, nil
 	}
 
 	playlist, err := e.client.GetPlaylist(url)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	needDownloadItems := utils.NeedDownloadList(option.Items, option.ItemStart, option.ItemEnd, len(playlist.Videos))
@@ -131,7 +132,7 @@ func (e *extractor) genPartByFormat(video *youtube.Video, f *youtube.Format) (*e
 	ext := getStreamExt(f.MimeType)
 	url, err := e.client.GetStreamURL(video, f)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	size := f.ContentLength
 	if size == 0 {
@@ -147,7 +148,7 @@ func (e *extractor) genPartByFormat(video *youtube.Video, f *youtube.Format) (*e
 func getVideoAudio(v *youtube.Video, mimeType string) (*youtube.Format, error) {
 	audioFormats := v.Formats.Type(mimeType).Type("audio")
 	if len(audioFormats) == 0 {
-		return nil, fmt.Errorf("no audio format found after filtering")
+		return nil, errors.New("no audio format found after filtering")
 	}
 	audioFormats.Sort()
 	return &audioFormats[0], nil

--- a/extractors/youtube/youtube.go
+++ b/extractors/youtube/youtube.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/kkdai/youtube/v2"
+
 	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"

--- a/extractors/youtube/youtube.go
+++ b/extractors/youtube/youtube.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/kkdai/youtube/v2"
-
 	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,8 @@ require (
 	github.com/json-iterator/go v1.1.11
 	github.com/kkdai/youtube/v2 v2.7.2
 	github.com/kr/pretty v0.1.0
-	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f // indirect
+	github.com/pkg/errors v0.9.1
+	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f
 	github.com/tidwall/gjson v1.9.3
 	github.com/urfave/cli/v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+
 	"github.com/pkg/errors"
 )
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
 )
 
 // GetDoc return Document object of the HTML string
 func GetDoc(html string) (*goquery.Document, error) {
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return doc, nil
 }
@@ -20,7 +21,7 @@ func GetDoc(html string) (*goquery.Document, error) {
 func GetImages(html, imgClass string, urlHandler func(string) string) (string, []string, error) {
 	doc, err := GetDoc(html)
 	if err != nil {
-		return "", nil, err
+		return "", nil, errors.WithStack(err)
 	}
 	title := Title(doc)
 	urls := make([]string, 0)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-
 	"github.com/pkg/errors"
 )
 

--- a/request/request.go
+++ b/request/request.go
@@ -12,11 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	cookiemonster "github.com/MercuryEngineering/CookieMonster"
 	"github.com/fatih/color"
 	"github.com/kr/pretty"
+	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/config"
 )

--- a/utils/ffmpeg.go
+++ b/utils/ffmpeg.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/pkg/errors"
 )
 
 func runMergeCmd(cmd *exec.Cmd, paths []string, mergeFilePath string) error {
@@ -12,7 +14,7 @@ func runMergeCmd(cmd *exec.Cmd, paths []string, mergeFilePath string) error {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("%s\n%s", err, stderr.String())
+		return errors.Errorf("%s\n%s", err, stderr.String())
 	}
 
 	if mergeFilePath != "" {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/md5"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -15,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 
 	"github.com/iawia002/lux/request"
@@ -227,7 +227,7 @@ func M3u8URLs(uri string) ([]string, error) {
 
 	html, err := request.Get(uri, "", nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	lines := strings.Split(html, "\n")
 	var urls []string

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/tidwall/gjson"
 
 	"github.com/iawia002/lux/request"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"github.com/tidwall/gjson"
 
 	"github.com/iawia002/lux/request"


### PR DESCRIPTION
use `github.com/pkg/errors` instead of `errors` package and print error stack when download fails.