### PR TITLE
Pretty print correctly formatted url

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -294,11 +294,13 @@ func download(c *cli.Context, videoURL string) error {
 	}
 
 	if c.Bool("json") {
-		jsonData, err := json.MarshalIndent(data, "", "\t")
-		if err != nil {
+		e := json.NewEncoder(os.Stdout)
+		e.SetIndent("", "\t")
+		e.SetEscapeHTML(false)
+		if err := e.Encode(data); err != nil {
 			return err
 		}
-		fmt.Printf("%s\n", jsonData)
+
 		return nil
 	}
 


### PR DESCRIPTION
```
λ  ./lux -j "https://www.douyin.com/video/7069676578136919310"
[
	{
		"url": "https://www.douyin.com/video/7069676578136919310",
		"site": "抖音 douyin.com",
		"title": "",
		"type": "video",
		"streams": {
			"default": {
				"id": "default",
				"quality": "default",
				"parts": [
					{
						"url": "https://aweme.snssdk.com/aweme/v1/play/?video_id=v0200fg10000c8e8ic3c77u9pvoe3jk0\u0026ratio=720p\u0026line=0",
						"size": 7997493,
						"ext": "mp4"
					}
				],
				"size": 7997493,
				"ext": "mp4",
				"NeedMux": false
			}
		},
		"caption": null,
		"err": null
	}
]
```

the url contains unicode \u0026,  use `enc.SetEscapeHTML(false)` to print `&`

https://go.dev/play/p/JlpdFV15_rI