### PR TITLE
Fix Fs parse failed while video length is too long

### DIFF
--- a/extractors/qq/qq.go
+++ b/extractors/qq/qq.go
@@ -24,7 +24,7 @@ type qqVideoInfo struct {
 			ID    int    `json:"id"`
 			Name  string `json:"name"`
 			Cname string `json:"cname"`
-			Fs    int    `json:"fs"`
+			Fs    int64  `json:"fs"`
 		} `json:"fi"`
 	} `json:"fl"`
 	Vl struct {


### PR DESCRIPTION
Bugs like:

> Downloading http://v.qq.com/x/page/u3229gcghm6.html error:
> json: cannot unmarshal number 2364254033 into Go struct field .fl.fi.fs of type int