### PR TITLE
feat: split-fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ $ HTTP_PROXY="socks5://127.0.0.1:1080/" lux -i "https://www.youtube.com/watch?v=
 
 ### Multi-Thread
 
+Use `-m` option to enable multi-thread download for single video.
+
+Use `-sf` option to enable multi-thread download for every fragment. Requires `-m` is set.
+
+> For example, in BiliBili download, use `-m -sf` can significantly increase speed.
+
 Use `-n` option to set the number of download threads(default is 10, only works for multiple-parts video).
 
 > **Special Tips:** Use too many threads in **mgtv** download will cause HTTP 403 error, we recommend setting the number of threads to **1**.

--- a/README.md
+++ b/README.md
@@ -354,13 +354,15 @@ $ HTTP_PROXY="socks5://127.0.0.1:1080/" lux -i "https://www.youtube.com/watch?v=
 
 ### Multi-Thread
 
-Use `-m` option to enable multi-thread download for single video.
+Use `--multi-thread` or `-m` multiple threads to download single video.
 
-Use `-sf` option to enable multi-thread download for every fragment. Requires `-m` is set.
+Use `--thread` or `-n` option to set the number of download threads(default is 10).
 
-> For example, in BiliBili download, use `-m -sf` can significantly increase speed.
-
-Use `-n` option to set the number of download threads(default is 10, only works for multiple-parts video).
+> Note: If the video has multi fragment, the number of actual download threads will increase.
+>
+> For example:
+> * If `-n` is set to 10, and the video has 2 fragments, then 20 threads will actually be used.
+> * If the video has 20 fragments, only 10 fragments are downloaded in the same time, the actual threads count is 100.
 
 > **Special Tips:** Use too many threads in **mgtv** download will cause HTTP 403 error, we recommend setting the number of threads to **1**.
 

--- a/app/app.go
+++ b/app/app.go
@@ -135,6 +135,11 @@ func New() *cli.App {
 				Aliases: []string{"m"},
 				Usage:   "Multiple threads to download single video",
 			},
+			&cli.BoolFlag{
+				Name:    "split-fragment",
+				Aliases: []string{"sf"},
+				Usage:   "Multiple threads to download every fragment. Require --multi-thread is set",
+			},
 			&cli.UintFlag{
 				Name:  "retry",
 				Value: 10,
@@ -306,6 +311,7 @@ func download(c *cli.Context, videoURL string) error {
 		FileNameLength: int(c.Uint("file-name-length")),
 		Caption:        c.Bool("caption"),
 		MultiThread:    c.Bool("multi-thread"),
+		SplitFragment:  c.Bool("split-fragment"),
 		ThreadNumber:   int(c.Uint("thread")),
 		RetryTimes:     int(c.Uint("retry")),
 		ChunkSizeMB:    int(c.Uint("chunk-size")),

--- a/app/app.go
+++ b/app/app.go
@@ -135,11 +135,6 @@ func New() *cli.App {
 				Aliases: []string{"m"},
 				Usage:   "Multiple threads to download single video",
 			},
-			&cli.BoolFlag{
-				Name:    "split-fragment",
-				Aliases: []string{"sf"},
-				Usage:   "Multiple threads to download every fragment. Require --multi-thread is set",
-			},
 			&cli.UintFlag{
 				Name:  "retry",
 				Value: 10,
@@ -311,7 +306,6 @@ func download(c *cli.Context, videoURL string) error {
 		FileNameLength: int(c.Uint("file-name-length")),
 		Caption:        c.Bool("caption"),
 		MultiThread:    c.Bool("multi-thread"),
-		SplitFragment:  c.Bool("split-fragment"),
 		ThreadNumber:   int(c.Uint("thread")),
 		RetryTimes:     int(c.Uint("retry")),
 		ChunkSizeMB:    int(c.Uint("chunk-size")),

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -34,10 +34,11 @@ type Options struct {
 	FileNameLength int
 	Caption        bool
 
-	MultiThread  bool
-	ThreadNumber int
-	RetryTimes   int
-	ChunkSizeMB  int
+	MultiThread   bool
+	SplitFragment bool
+	ThreadNumber  int
+	RetryTimes    int
+	ChunkSizeMB   int
 	// Aria2
 	UseAria2RPC bool
 	Aria2Token  string
@@ -645,7 +646,12 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 		wgp.Add()
 		go func(part *extractors.Part, fileName string) {
 			defer wgp.Done()
-			err := downloader.save(part, data.URL, fileName)
+			var err error
+			if downloader.option.SplitFragment {
+				err = downloader.multiThreadSave(part, data.URL, fileName)
+			} else {
+				err = downloader.save(part, data.URL, fileName)
+			}
 			if err != nil {
 				lock.Lock()
 				errs = append(errs, err)

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -34,11 +34,10 @@ type Options struct {
 	FileNameLength int
 	Caption        bool
 
-	MultiThread   bool
-	SplitFragment bool
-	ThreadNumber  int
-	RetryTimes    int
-	ChunkSizeMB   int
+	MultiThread  bool
+	ThreadNumber int
+	RetryTimes   int
+	ChunkSizeMB  int
 	// Aria2
 	UseAria2RPC bool
 	Aria2Token  string
@@ -647,7 +646,7 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 		go func(part *extractors.Part, fileName string) {
 			defer wgp.Done()
 			var err error
-			if downloader.option.SplitFragment {
+			if downloader.option.MultiThread {
 				err = downloader.multiThreadSave(part, data.URL, fileName)
 			} else {
 				err = downloader.save(part, data.URL, fileName)


### PR DESCRIPTION
This can speed up bilibili video download.

Bilibili videos are usually divided into 2 fragments (A&V).

Therefore, before this PR, the program uses only 2 threads to download when `-thread 10`.