### PR TITLE
Remove Redundant Character Escape in RegExp

### DIFF
--- a/extractors/mgtv/mgtv.go
+++ b/extractors/mgtv/mgtv.go
@@ -91,7 +91,7 @@ func mgtvM3u8(url string) ([]mgtvURLInfo, int64, error) {
 func encodeTk2(str string) string {
 	encodeString := base64.StdEncoding.EncodeToString([]byte(str))
 	r1 := regexp.MustCompile(`/\+/g`)
-	r2 := regexp.MustCompile(`/\//g`)
+	r2 := regexp.MustCompile(`///g`)
 	r3 := regexp.MustCompile(`/=/g`)
 	r1.ReplaceAllString(encodeString, "_")
 	r2.ReplaceAllString(encodeString, "~")

--- a/extractors/pornhub/pornhub.go
+++ b/extractors/pornhub/pornhub.go
@@ -78,7 +78,7 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		title = "pornhub video"
 	}
 
-	reg, err := regexp.Compile(`<script\b[^>]*>([\s\S]*?)<\/script>`)
+	reg, err := regexp.Compile(`<script\b[^>]*>([\s\S]*?)</script>`)
 	if err != nil {
 		return nil, errors.WithStack(extractors.ErrInvalidRegularExpression)
 	}

--- a/extractors/xinpianchang/xinpianchang.go
+++ b/extractors/xinpianchang/xinpianchang.go
@@ -45,8 +45,8 @@ func (e *extractor) Extract(url string, option extractors.Options) ([]*extractor
 		return nil, errors.WithStack(err)
 	}
 
-	r1 := regexp.MustCompile(`vid = \"(.+?)\";`)
-	r2 := regexp.MustCompile(`modeServerAppKey = \"(.+?)\";`)
+	r1 := regexp.MustCompile(`vid = "(.+?)";`)
+	r2 := regexp.MustCompile(`modeServerAppKey = "(.+?)";`)
 
 	vid := r1.FindSubmatch([]byte(html))[1]
 	appKey := r2.FindSubmatch([]byte(html))[1]


### PR DESCRIPTION
\/ → \
\" → "
🙂