### PR TITLE
Updated API for requesting subtitles from bilibili

### DIFF
--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -500,7 +500,7 @@ func getExtFromMimeType(mimeType string) string {
 
 func getSubTitleCaptionPart(aid int, cid int) *extractors.CaptionPart {
 	jsonString, err := request.Get(
-		fmt.Sprintf("http://api.bilibili.com/x/web-interface/view?aid=%d&cid=%d", aid, cid), referer, nil,
+		fmt.Sprintf("http://api.bilibili.com/x/player/wbi/v2?aid=%d&cid=%d", aid, cid), referer, nil,
 	)
 	if err != nil {
 		return nil
@@ -512,7 +512,7 @@ func getSubTitleCaptionPart(aid int, cid int) *extractors.CaptionPart {
 	}
 	return &extractors.CaptionPart{
 		Part: extractors.Part{
-			URL: stu.Data.SubtitleInfo.SubtitleList[0].SubtitleUrl,
+			URL: fmt.Sprintf("https:%s", stu.Data.SubtitleInfo.SubtitleList[0].SubtitleUrl),
 			Ext: "srt",
 		},
 		Transform: subtitleTransform,

--- a/extractors/bilibili/types.go
+++ b/extractors/bilibili/types.go
@@ -131,7 +131,7 @@ type subtitleProperty struct {
 
 type subtitleInfo struct {
 	AllowSubmit  bool               `json:"allow_submit"`
-	SubtitleList []subtitleProperty `json:"list"`
+	SubtitleList []subtitleProperty `json:"subtitles"`
 }
 
 type bilibiliWebInterfaceData struct {


### PR DESCRIPTION
The previous API URL still works, but it now only returns an empty `subtitle_url`, making `lux` unable to download subtitles anymore. The JSON file returned by the new API URL has changed a bit, but not much as far as subtitles are concerned, and the `bilibiliWebInterface` struct is only used once on the following line, so I don't think there will be unexpected side effects.
https://github.com/iawia002/lux/blob/90109ff79f7c6a798c35a2d5c9b8c570a616f226/extractors/bilibili/bilibili.go#L508