### PR TITLE
Add --audio-only flag

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -89,6 +89,11 @@ func New() *cli.App {
 				Aliases: []string{"f"},
 				Usage:   "Select specific stream to download",
 			},
+			&cli.BoolFlag{
+				Name:    "audio-only",
+				Aliases: []string{"ao"},
+				Usage:   "Download audio only at best quality",
+			},
 			&cli.StringFlag{
 				Name:    "file",
 				Aliases: []string{"F"},
@@ -300,6 +305,7 @@ func download(c *cli.Context, videoURL string) error {
 		Silent:         c.Bool("silent"),
 		InfoOnly:       c.Bool("info"),
 		Stream:         c.String("stream-format"),
+		AudioOnly:      c.Bool("audio-only"),
 		Refer:          c.String("refer"),
 		OutputPath:     c.String("output-path"),
 		OutputName:     c.String("output-name"),

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -570,16 +570,21 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 	}
 
 	if downloader.option.AudioOnly {
+		var isFound bool
 		for _, s := range sortedStreams {
 			// Looking for the best quality
-			matches, ok := regexp.MatchString("audio", s.Quality)
-			if ok != nil {
-				return errors.Errorf("No audio stream found")
+			matches, err := regexp.MatchString("audio", s.Quality)
+			if err != nil {
+				return err
 			}
 			if matches {
+				isFound = true
 				stream, _ = data.Streams[s.ID]
 				break
 			}
+		}
+		if !isFound {
+			return errors.Errorf("No audio stream found")
 		}
 	}
 

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -28,6 +28,7 @@ type Options struct {
 	InfoOnly       bool
 	Silent         bool
 	Stream         string
+	AudioOnly      bool
 	Refer          string
 	OutputPath     string
 	OutputName     string
@@ -566,6 +567,20 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 	stream, ok := data.Streams[streamName]
 	if !ok {
 		return errors.Errorf("no stream named %s", streamName)
+	}
+
+	if downloader.option.AudioOnly {
+		for _, s := range sortedStreams {
+			// Looking for the best quality
+			matches, ok := regexp.MatchString("audio", s.Quality)
+			if ok != nil {
+				return errors.Errorf("No audio stream found")
+			}
+			if matches {
+				stream, _ = data.Streams[s.ID]
+				break
+			}
+		}
 	}
 
 	if !downloader.option.Silent {

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -571,15 +571,16 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 
 	if downloader.option.AudioOnly {
 		var isFound bool
+		reg, err := regexp.Compile("audio+")
+		if err != nil {
+			return err
+		}
+
 		for _, s := range sortedStreams {
 			// Looking for the best quality
-			matches, err := regexp.MatchString("audio", s.Quality)
-			if err != nil {
-				return err
-			}
-			if matches {
+			if reg.MatchString(s.Quality) {
 				isFound = true
-				stream, _ = data.Streams[s.ID]
+				stream = data.Streams[s.ID]
 				break
 			}
 		}


### PR DESCRIPTION
I think this option is more user friendly than choosing audio stream from streams output.

I tested it out with youtube videos, and it's working pretty fine.