### PR TITLE
fixes rumble loop

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"strconv"
 	"strings"
 	"time"
@@ -54,9 +55,14 @@ func Request(method, url string, body io.Reader, headers map[string]string) (*ht
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
 	client := &http.Client{
 		Transport: transport,
 		Timeout:   15 * time.Minute,
+		Jar:       jar,
 	}
 
 	req, err := http.NewRequest(method, url, body)


### PR DESCRIPTION
I got a redirect loop when trying to download a video from rumble. I looked in chrome developer tools at the requests and there were a few cookies being set on the first redirect, that i guessed were not being sent by the default go client.

Adding a cookie jar fixed the issue for me.

