### PR TITLE
fix no streams for newly published rumble videos

### DIFF
--- a/extractors/rumble/rumble.go
+++ b/extractors/rumble/rumble.go
@@ -158,17 +158,6 @@ type videoQualities struct {
 	Q2161 struct{ streamInfo } `json:"2161"`
 }
 
-type tarVideoQualities struct {
-	Q240  struct{ streamInfo } `json:"240"`
-	Q360  struct{ streamInfo } `json:"360"`
-	Q480  struct{ streamInfo } `json:"480"`
-	Q720  struct{ streamInfo } `json:"720"`
-	Q1080 struct{ streamInfo } `json:"1080"`
-	Q1440 struct{ streamInfo } `json:"1440"`
-	Q2160 struct{ streamInfo } `json:"2160"`
-	Q2161 struct{ streamInfo } `json:"2161"`
-}
-
 // Video payload for adaptive stream and different qualities
 type rumbleStreams struct {
 	FMp4 struct {

--- a/extractors/rumble/rumble_test.go
+++ b/extractors/rumble/rumble_test.go
@@ -19,10 +19,31 @@ func TestRumble(t *testing.T) {
 				Title: "Just Say YES to Climate Lockdowns!",
 			},
 		},
+		{
+			name: "normal test",
+			args: test.Args{
+				URL:   "https://rumble.com/v6rmfm1-monday-full-show-33125-hhs-head-rfk-jr.-pledges-to-stopv.html",
+				Title: "MONDAY FULL SHOW 3/31/25 — HHS Head RFK Jr. Pledges To Stopv",
+			},
+		},
 	}
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			New().Extract(tt.args.URL, extractors.Options{})
+			data, err := New().Extract(tt.args.URL, extractors.Options{})
+			if err != nil {
+				t.Error(err)
+			}
+			for _, d := range data {
+				found := false
+				for _, s := range d.Streams {
+					if s.Size > 0 {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("no streams found in test %d", i)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Had an issue where newly uploaded videos had no streams. The json file returned has a new section in that is called tar, its a m3u8 files for each resolution that include chunks of a mp2t file.

Updated the library to correctly get the new type of stream