### PR TITLE
for bili website: Add -ao to download audio only; output filename support placeholder %author %date %title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ $ lux -j "https://www.bilibili.com/video/av20203945"
   -o string
     	Specify the output path
   -O string
-    	Specify the output file name
+    	Specify the output file name.  supports placeholder %author %date %title. 
 ```
 
 #### Subtitle:

--- a/app/app.go
+++ b/app/app.go
@@ -274,6 +274,7 @@ func New() *cli.App {
 func download(c *cli.Context, videoURL string) error {
 	data, err := extractors.Extract(videoURL, extractors.Options{
 		Playlist:         c.Bool("playlist"),
+		AudioOnly:        c.Bool("audio-only"),
 		Items:            c.String("items"),
 		ItemStart:        int(c.Uint("start")),
 		ItemEnd:          int(c.Uint("end")),

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"github.com/cheggaaa/pb/v3"
+	"github.com/pkg/errors"
 	"io"
 	"net/http"
 	"os"
@@ -12,11 +14,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"sync"
 	"time"
-
-	"github.com/cheggaaa/pb/v3"
-	"github.com/pkg/errors"
 
 	"github.com/iawia002/lux/extractors"
 	"github.com/iawia002/lux/request"
@@ -558,9 +558,26 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 		return nil
 	}
 
+	/*title := downloader.option.OutputName
+	if title == "" {
+		title = data.Title
+	}*/
 	title := downloader.option.OutputName
 	if title == "" {
 		title = data.Title
+	} else {
+		// 创建占位符映射
+		placeholders := map[string]string{
+			"%title": data.Title,
+			// 可以根据需要添加更多占位符
+			"%author": data.Author,
+			"%date":   data.Date,
+		}
+
+		// 替换所有占位符
+		for placeholder, value := range placeholders {
+			title = strings.ReplaceAll(title, placeholder, value)
+		}
 	}
 	title = utils.FileName(title, "", downloader.option.FileNameLength)
 

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -485,6 +485,17 @@ func bilibiliDownload(options bilibiliOptions, extractOption extractors.Options)
 		return extractors.EmptyData(options.url, err)
 	}
 	title := parser.Title(doc)
+	var author = strings.TrimSpace(doc.Find("a.up-name").Text())
+	var datePart = doc.Find("div.pubdate-ip-text").Text()
+	if len(strings.TrimSpace(datePart)) > 0 {
+		parts := strings.Split(datePart, " ")
+		// 获取第一部分，即年月日
+		if len(parts) > 0 {
+			datePart = parts[0]
+		}
+	}
+	//title = fmt.Sprintf("%s %s", datePart, title)
+	title = fmt.Sprintf("%s", title)
 	if options.subtitle != "" {
 		pageString := ""
 		if options.page > 0 {
@@ -500,6 +511,8 @@ func bilibiliDownload(options bilibiliOptions, extractOption extractors.Options)
 	return &extractors.Data{
 		Site:    "哔哩哔哩 bilibili.com",
 		Title:   title,
+		Date:    datePart,
+		Author:  author,
 		Type:    extractors.DataTypeVideo,
 		Streams: streams,
 		Captions: map[string]*extractors.CaptionPart{

--- a/extractors/bilibili/bilibili_test.go
+++ b/extractors/bilibili/bilibili_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestBilibili(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     test.Args
-		playlist bool
+		name      string
+		args      test.Args
+		playlist  bool
+		audioonly bool
 	}{
 		{
 			name: "normal test 1",
@@ -27,7 +28,8 @@ func TestBilibili(t *testing.T) {
 				URL:   "https://www.bilibili.com/video/av41301960",
 				Title: "【英雄联盟】2019赛季CG 《觉醒》",
 			},
-			playlist: false,
+			playlist:  false,
+			audioonly: true,
 		},
 		{
 			name: "bangumi test",
@@ -85,6 +87,13 @@ func TestBilibili(t *testing.T) {
 				_, err = New().Extract(tt.args.URL, extractors.Options{
 					Playlist:     true,
 					ThreadNumber: 9,
+				})
+				test.CheckError(t, err)
+			}
+			if tt.audioonly {
+				// for playlist, we don't check the data
+				_, err = New().Extract(tt.args.URL, extractors.Options{
+					AudioOnly: true,
 				})
 				test.CheckError(t, err)
 			} else {

--- a/extractors/types.go
+++ b/extractors/types.go
@@ -45,10 +45,12 @@ const (
 // Data is the main data structure for the whole video data.
 type Data struct {
 	// URL is used to record the address of this download
-	URL   string   `json:"url"`
-	Site  string   `json:"site"`
-	Title string   `json:"title"`
-	Type  DataType `json:"type"`
+	URL    string   `json:"url"`
+	Site   string   `json:"site"`
+	Title  string   `json:"title"`
+	Author string   `json:"author"`
+	Date   string   `json:"date"`
+	Type   DataType `json:"type"`
 	// each stream has it's own Parts and Quality
 	Streams map[string]*Stream `json:"streams"`
 	// danmaku, subtitles, etc
@@ -115,6 +117,9 @@ type Options struct {
 
 	// EpisodeTitleOnly indicates file name of each bilibili episode doesn't include the playlist title
 	EpisodeTitleOnly bool
+
+	// AudioOnly
+	AudioOnly bool
 
 	YoukuCcode    string
 	YoukuCkey     string


### PR DESCRIPTION
for bili website: Add -ao to download audio only; output filename support placeholder %author %date %title.

----
对于bili: 添加-ao只下载音频；自定义文件名支持占位符 %author %date %title 替换