### PR TITLE
fix(bilibili): update regex to correctly extract data string

### DIFF
--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -95,7 +95,7 @@ type bilibiliOptions struct {
 }
 
 func extractBangumi(url, html string, extractOption extractors.Options) ([]*extractors.Data, error) {
-	dataString := utils.MatchOneOf(html, `<script\s+id="__NEXT_DATA__"\s+type="application/json"\s*>(.*?)</script\s*>`)[1]
+	dataString := utils.MatchOneOf(html, `const playurlSSRData = ({[\s\S]+})`)[1]
 	epArrayString := utils.MatchOneOf(dataString, `"episode_info"\s*:\s*(.+?)\s*,\s*"season_info"`)[1]
 	fullVideoIdString := utils.MatchOneOf(dataString, `"videoId"\s*:\s*"(ep|ss)(\d+)"`)
 	epSsString := fullVideoIdString[1] // "ep" or "ss"


### PR DESCRIPTION
Update regex to extract the data from the HTML correctly

Fixes #1411 

Before: 
<img width="1217" height="467" alt="image" src="https://github.com/user-attachments/assets/df4ead79-6e83-46bb-86d3-78031639e924" />

After:
<img width="684" height="222" alt="image" src="https://github.com/user-attachments/assets/2e3eda41-4510-4fbb-874a-8820b5233148" />

