### PR TITLE
feat: export Bar field in Downloader struct for external progress tracking

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -50,7 +50,7 @@ type Options struct {
 
 // Downloader is the default downloader.
 type Downloader struct {
-	bar    *pb.ProgressBar
+	Bar    *pb.ProgressBar
 	option Options
 }
 
@@ -115,7 +115,7 @@ func (downloader *Downloader) writeFile(url string, file *os.File, headers map[s
 	}
 	defer res.Body.Close() // nolint
 
-	barWriter := downloader.bar.NewProxyWriter(file)
+	barWriter := downloader.Bar.NewProxyWriter(file)
 	// Note that io.Copy reads 32kb(maximum) from input and writes them to output, then repeats.
 	// So don't worry about memory.
 	written, copyErr := io.Copy(barWriter, res.Body)
@@ -137,7 +137,7 @@ func (downloader *Downloader) save(part *extractors.Part, refer, fileName string
 	// Skip segment file
 	// TODO: Live video URLs will not return the size
 	if exists && fileSize == part.Size {
-		downloader.bar.Add64(fileSize)
+		downloader.Bar.Add64(fileSize)
 		return nil
 	}
 
@@ -157,7 +157,7 @@ func (downloader *Downloader) save(part *extractors.Part, refer, fileName string
 		// range start from 0, 0-1023 means the first 1024 bytes of the file
 		headers["Range"] = fmt.Sprintf("bytes=%d-", tempFileSize)
 		file, fileError = os.OpenFile(tempFilePath, os.O_APPEND|os.O_WRONLY, 0644)
-		downloader.bar.Add64(tempFileSize)
+		downloader.Bar.Add64(tempFileSize)
 	} else {
 		file, fileError = os.Create(tempFilePath)
 	}
@@ -236,7 +236,7 @@ func (downloader *Downloader) multiThreadSave(dataPart *extractors.Part, refer, 
 	// Skip segment file
 	// TODO: Live video URLs will not return the size
 	if exists && fileSize == dataPart.Size {
-		downloader.bar.Add64(fileSize)
+		downloader.Bar.Add64(fileSize)
 		return nil
 	}
 	tmpFilePath := filePath + DOWNLOAD_FILE_EXT
@@ -246,7 +246,7 @@ func (downloader *Downloader) multiThreadSave(dataPart *extractors.Part, refer, 
 	}
 	if tmpExists {
 		if tmpFileSize == dataPart.Size {
-			downloader.bar.Add64(dataPart.Size)
+			downloader.Bar.Add64(dataPart.Size)
 			return os.Rename(tmpFilePath, filePath)
 		}
 
@@ -331,7 +331,7 @@ func (downloader *Downloader) multiThreadSave(dataPart *extractors.Part, refer, 
 		}
 	}
 	if savedSize > 0 {
-		downloader.bar.Add64(savedSize)
+		downloader.Bar.Add64(savedSize)
 		if savedSize == dataPart.Size {
 			return mergeMultiPart(filePath, parts)
 		}
@@ -653,9 +653,9 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 		return nil
 	}
 
-	downloader.bar = progressBar(stream.Size)
+	downloader.Bar = progressBar(stream.Size)
 	if !downloader.option.Silent {
-		downloader.bar.Start()
+		downloader.Bar.Start()
 	}
 	if len(stream.Parts) == 1 {
 		// only one fragment
@@ -669,7 +669,7 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 		if err != nil {
 			return err
 		}
-		downloader.bar.Finish()
+		downloader.Bar.Finish()
 
 		if downloader.option.EmbedSubtitle && len(subtitlePaths) > 0 {
 			if !downloader.option.Silent {
@@ -726,7 +726,7 @@ func (downloader *Downloader) Download(data *extractors.Data) error {
 	if len(errs) > 0 {
 		return errs[0]
 	}
-	downloader.bar.Finish()
+	downloader.Bar.Finish()
 
 	if data.Type != extractors.DataTypeVideo || downloader.option.AudioOnly {
 		return nil


### PR DESCRIPTION
## Summary

  This PR exports the `Bar` field in the `Downloader` struct by changing it from `bar` (unexported) to `Bar` (exported). This allows external packages to access the progress bar instance for custom progress tracking and monitoring purposes.

  ## Motivation

  When using lux as a library (rather than a CLI tool), developers may need to:

  - Monitor download progress programmatically
  - Integrate download progress into their own UI/dashboard
  - Implement custom progress reporting (e.g., sending progress updates via WebSocket, logging to external services)
  - Build wrapper applications that need real-time download status

  Previously, the `bar` field was unexported, making it impossible for external packages to access the progress bar state. This change enables these use cases while maintaining full backward compatibility.

  ## Changes

  - **File**: `downloader/downloader.go`
  - **Change**: Renamed `bar` field to `Bar` in the `Downloader` struct
  - **Impact**: All internal references updated from `downloader.bar` to `downloader.Bar`

  ## Code Change

  ```go
  // Before
  type Downloader struct {
      bar    *pb.ProgressBar
      option Options
  }

  // After
  type Downloader struct {
      Bar    *pb.ProgressBar
      option Options
  }

  Usage Example

  import (
      "github.com/iawia002/lux/downloader"
  )

  func main() {
      d := downloader.New(downloader.Options{})

      // Start download in goroutine
      go d.Download(data)

      // Access progress bar for custom monitoring
      if d.Bar != nil {
          current := d.Bar.Current()
          total := d.Bar.Total()
          // Custom progress handling...
      }
  }

  Backward Compatibility

  This change is fully backward compatible:
  - No existing public APIs are modified
  - No function signatures are changed
  - Existing CLI usage remains unaffected
  - Only adds new capability for library users

  Testing

  - Existing tests pass
  - Manual testing of download functionality
  - Progress bar displays correctly during downloads